### PR TITLE
update namespace for docker_secret file

### DIFF
--- a/k8s_setup/docker-credentials-secret.yaml.tpl
+++ b/k8s_setup/docker-credentials-secret.yaml.tpl
@@ -5,6 +5,6 @@ data:
 kind: Secret
 metadata:
   name: docker-credentials
-  namespace: default
+  namespace: kubeflow
 type: Opaque
 


### PR DESCRIPTION
I'm trying the seldon example with kubeflow, hit a problem below that the docker-credentials cannot be found but the secret is created.

```
 Warning  FailedMount  1m (x9 over 4m)  kubelet, 172.16.27.165  MountVolume.SetUp failed for volume "my-secret-vol" : secrets "docker-credentials" not found
```

Check the yaml file, the namespace is `default`, but we are working in the `kubeflow` in the Readme file and documents. so suggest to update the namespace to `kubeflow` to avoid misleading readers. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/example-seldon/26)
<!-- Reviewable:end -->
