### PR TITLE
update serving-tf-mnist-workflow.md

### DIFF
--- a/workflows/serving-tf-mnist-workflow.md
+++ b/workflows/serving-tf-mnist-workflow.md
@@ -6,7 +6,7 @@ Comments on the [serving-tf-mnist-workflow.yaml](serving-tf-mnist-workflow.yaml)
 
 To serve our runtime model we create:
 
- * [```models/tf_mnist/runtime/wrap.sh```](models/tf_mnist/runtime/wrap.sh) to wrap model using the seldon-core python wrapper.
+ * [```models/tf_mnist/runtime/wrap.sh```](../models/tf_mnist/runtime/wrap.sh) to wrap model using the seldon-core python wrapper.
  * An Argo workflow to:
     * Wrap the runtime model, builds a docker container for it and optionally push it to your repo
     * Starts a seldon deployment that will run and expose your model
@@ -24,6 +24,8 @@ To serve our runtime model we create:
    * The Docker user to use when pushing an image to DockerHub
  * build-push-image
    * Whether to build and push the image to an external repo on DockerHub (true/false)
+ * deploy-model
+   * Whether to start a seldon deployment to run and expose your model (true/false)
 
 
 


### PR DESCRIPTION
The PR is to update serving-tf-mnist-workflow.md, includes two changes:
1. fixed one bad link.
2. Added one introduction for workflow parameters `deploy-model` which is in the `serving-tf-mnist-workflow.yaml`.

Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/example-seldon/27)
<!-- Reviewable:end -->
