### PR TITLE
update apiVersion for SeldonDeployment

### DIFF
--- a/workflows/serving-r-mnist-workflow.yaml
+++ b/workflows/serving-r-mnist-workflow.yaml
@@ -77,7 +77,7 @@ spec:
       action: apply             #can be any kubectl action (e.g. create, delete, apply, patch)
       #successCondition: ? 
       manifest: |   #put your kubernetes spec here
-       apiVersion: "machinelearning.seldon.io/v1alpha1"
+       apiVersion: "machinelearning.seldon.io/v1alpha2"
        kind: "SeldonDeployment"
        metadata: 
          labels: 

--- a/workflows/serving-sk-mnist-workflow.yaml
+++ b/workflows/serving-sk-mnist-workflow.yaml
@@ -77,7 +77,7 @@ spec:
       action: apply             #can be any kubectl action (e.g. create, delete, apply, patch)
       #successCondition: ? 
       manifest: |   #put your kubernetes spec here
-       apiVersion: "machinelearning.seldon.io/v1alpha1"
+       apiVersion: "machinelearning.seldon.io/v1alpha2"
        kind: "SeldonDeployment"
        metadata: 
          labels: 

--- a/workflows/serving-tf-mnist-workflow.yaml
+++ b/workflows/serving-tf-mnist-workflow.yaml
@@ -70,7 +70,7 @@ spec:
       action: apply             #can be any kubectl action (e.g. create, delete, apply, patch)
       #successCondition: ? 
       manifest: |   #put your kubernetes spec here
-       apiVersion: "machinelearning.seldon.io/v1alpha1"
+       apiVersion: "machinelearning.seldon.io/v1alpha2"
        kind: "SeldonDeployment"
        metadata: 
          labels: 


### PR DESCRIPTION
While run seldon with kubeflow, have a problem that the seldon serving workflow cannot be started due to no matches for kind "SeldonDeployment" in version "machinelearning.seldon.io/v1alpha1".
```
# argo get seldon-tf-deploy-zgg6c
Name:                seldon-tf-deploy-zgg6c
.....
STEP                       PODNAME                            DURATION  MESSAGE
 ✖ seldon-tf-deploy-zgg6c                                               child 'seldon-tf-deploy-zgg6c-81160477' failed
 ├---✔ build-push          seldon-tf-deploy-zgg6c-2369403710  12m       
 └---✖ serve               seldon-tf-deploy-zgg6c-81160477    7s        error: unable to recognize "/tmp/manifest.yaml": no matches for kind "SeldonDeployment" in version "machinelearning.seldon.io/v1alpha1"
```

Checked CRD, the apiversion should be v1alpha2 after seldon is installed by kubeflow 0.4.0.
```
# kubectl get crd seldondeployments.machinelearning.seldon.io -o yaml  |grep -i v1alpha*
  version: v1alpha2
  - name: v1alpha2
  - v1alpha2
```

And the apiversion in the *json files under `k8s_serving` folder such as `./k8s_serving/serving_model.json` have been updated to `v1alpha2`.

**The PR is to update the apiversion in the files under `workflows/`**, with the patch, the workflow can be finished normally.
```
# argo list
NAME                      STATUS      AGE   DURATION
seldon-tf-deploy-vj8fw    Succeeded   30m   13m
kubeflow-tf-train-b7l2v   Succeeded   3h    11m
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/example-seldon/28)
<!-- Reviewable:end -->
