### PR TITLE
update workflow to componentSpecs

### DIFF
--- a/workflows/serving-r-mnist-workflow.yaml
+++ b/workflows/serving-r-mnist-workflow.yaml
@@ -92,24 +92,25 @@ spec:
            - 
              annotations: 
                predictor_version: "v1"
-             componentSpec: 
-               spec: 
-                 containers: 
-                   - 
-                     image: "{{workflow.parameters.docker-user}}/rmnistclassifier_runtime:{{workflow.parameters.version}}"
-                     imagePullPolicy: "Always"
-                     name: "mnist-classifier"
-                     volumeMounts: 
-                       - 
-                         mountPath: "/data"
-                         name: "persistent-storage"
-                 terminationGracePeriodSeconds: 1
-                 volumes: 
-                   - 
-                     name: "persistent-storage"
-                     volumeSource: 
-                       persistentVolumeClaim: 
-                         claimName: "nfs-1"
+             componentSpecs:
+               - 
+                 spec: 
+                   containers: 
+                     - 
+                       image: "{{workflow.parameters.docker-user}}/rmnistclassifier_runtime:{{workflow.parameters.version}}"
+                       imagePullPolicy: "Always"
+                       name: "mnist-classifier"
+                       volumeMounts: 
+                         - 
+                           mountPath: "/data"
+                           name: "persistent-storage"
+                   terminationGracePeriodSeconds: 1
+                   volumes: 
+                     - 
+                       name: "persistent-storage"
+                       volumeSource: 
+                         persistentVolumeClaim: 
+                           claimName: "nfs-1"
              graph: 
                children: []
                endpoint: 

--- a/workflows/serving-sk-mnist-workflow.yaml
+++ b/workflows/serving-sk-mnist-workflow.yaml
@@ -92,24 +92,25 @@ spec:
            - 
              annotations: 
                predictor_version: "v1"
-             componentSpec: 
-               spec: 
-                 containers: 
-                   - 
-                     image: "{{workflow.parameters.docker-user}}/skmnistclassifier_runtime:{{workflow.parameters.version}}"
-                     imagePullPolicy: "Always"
-                     name: "mnist-classifier"
-                     volumeMounts: 
-                       - 
-                         mountPath: "/data"
-                         name: "persistent-storage"
-                 terminationGracePeriodSeconds: 1
-                 volumes: 
-                   - 
-                     name: "persistent-storage"
-                     volumeSource: 
-                       persistentVolumeClaim: 
-                         claimName: "nfs-1"
+             componentSpecs:
+               - 
+                 spec: 
+                   containers: 
+                     - 
+                       image: "{{workflow.parameters.docker-user}}/skmnistclassifier_runtime:{{workflow.parameters.version}}"
+                       imagePullPolicy: "Always"
+                       name: "mnist-classifier"
+                       volumeMounts: 
+                         - 
+                           mountPath: "/data"
+                           name: "persistent-storage"
+                   terminationGracePeriodSeconds: 1
+                   volumes: 
+                     - 
+                       name: "persistent-storage"
+                       volumeSource: 
+                         persistentVolumeClaim: 
+                           claimName: "nfs-1"
              graph: 
                children: []
                endpoint: 

--- a/workflows/serving-tf-mnist-workflow.yaml
+++ b/workflows/serving-tf-mnist-workflow.yaml
@@ -85,24 +85,25 @@ spec:
            - 
              annotations: 
                predictor_version: "v1"
-             componentSpec: 
-               spec: 
-                 containers: 
-                   - 
-                     image: "{{workflow.parameters.docker-user}}/deepmnistclassifier_runtime:{{workflow.parameters.version}}"
-                     imagePullPolicy: "Always"
-                     name: "mnist-classifier"
-                     volumeMounts: 
-                       - 
-                         mountPath: "/data"
-                         name: "persistent-storage"
-                 terminationGracePeriodSeconds: 1
-                 volumes: 
-                   - 
-                     name: "persistent-storage"
-                     volumeSource: 
-                       persistentVolumeClaim: 
-                         claimName: "nfs-1"
+             componentSpecs:
+               - 
+                 spec: 
+                   containers: 
+                     - 
+                       image: "{{workflow.parameters.docker-user}}/deepmnistclassifier_runtime:{{workflow.parameters.version}}"
+                       imagePullPolicy: "Always"
+                       name: "mnist-classifier"
+                       volumeMounts: 
+                         - 
+                           mountPath: "/data"
+                           name: "persistent-storage"
+                   terminationGracePeriodSeconds: 1
+                   volumes: 
+                     - 
+                       name: "persistent-storage"
+                       volumeSource: 
+                         persistentVolumeClaim: 
+                           claimName: "nfs-1"
              graph: 
                children: []
                endpoint: 


### PR DESCRIPTION
Ran into a problem that the seldondeployment mnist-classifier cannot be started after #28 
```
# kubectl describe seldondeployment mnist-classifier
....
Status:
  Description:  Cannot find field: componentSpec in message seldon.protos.PredictorSpec
  State:        Failed
Events:         <none>
```

Checked the details, the `componentSpec` should be updated to `componentSpecs`. The PR updated that. with the patch, the seldondeployment can be finished normally.
```
# kubectl describe seldondeployment mnist-classifier
.....
Status:
  Predictor Status:
    Name:                mnist-classifier-mnist-classifier-svc-orch
    Replicas:            1
    Replicas Available:  1
    Name:                mnist-classifier-mnist-classifier-mnist-classifier-0
    Replicas:            1
    Replicas Available:  1
  State:                 Available
Events:                  <none>
```