### PR TITLE
fix hard code for workflow name

### DIFF
--- a/workflows/training-r-mnist-workflow.yaml
+++ b/workflows/training-r-mnist-workflow.yaml
@@ -75,7 +75,7 @@ spec:
          - apiVersion: argoproj.io/v1alpha1
            kind: Workflow
            controller: true
-           name: kubeflow-train
+           name: {{workflow.name}}
            uid: {{workflow.uid}}
        spec: 
          template: 

--- a/workflows/training-sk-mnist-workflow.yaml
+++ b/workflows/training-sk-mnist-workflow.yaml
@@ -75,7 +75,7 @@ spec:
          - apiVersion: argoproj.io/v1alpha1
            kind: Workflow
            controller: true
-           name: kubeflow-train
+           name: {{workflow.name}}
            uid: {{workflow.uid}}
        spec: 
          template: 

--- a/workflows/training-tf-mnist-workflow.yaml
+++ b/workflows/training-tf-mnist-workflow.yaml
@@ -79,7 +79,7 @@ spec:
          - apiVersion: argoproj.io/v1alpha1
            kind: Workflow
            controller: true
-           name: kubeflow-train
+           name: {{workflow.name}}
            uid: {{workflow.uid}}
        spec: 
          tfReplicaSpecs: 


### PR DESCRIPTION
After workflow finished, checked the tfjobs/job, found the control workflow name is `kubeflow-train`, which cannot be found in k8s cluser, that's caused by the name is hard code in the workflow difination files.

The PR is to enhance the hard code of workflow name. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/example-seldon/33)
<!-- Reviewable:end -->
