### PR TITLE
add owner for the project

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+  - cliveseldon
+reviewers:
+  - cliveseldon
+  - jinchihe


### PR DESCRIPTION
Hi @cliveseldon ,

Recently I got some questions from mail and Slack, seems some users are trying the seldon on Kubeflow, and ask me since there are some PRs from me.  And as another projects in Kubeflow, we should have the OWNER for this, so that user can got reviewing the PR or consultation. Thanks a lot!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/example-seldon/36)
<!-- Reviewable:end -->
